### PR TITLE
Argue gen hist

### DIFF
--- a/src/generators/mythological_era_generator.cpp
+++ b/src/generators/mythological_era_generator.cpp
@@ -53,9 +53,7 @@ void his_gen::Mythological_era_generator::Run()
                                       m_ticks_completed);
 
       // With new entities involved, manage events, including scheduled events
-      m_myth_narrator.Manage_events(m_generated_history.Get_entities(),
-                                    m_generated_history.Get_events(),
-                                    m_generated_history.Get_entity_relationships(),
+      m_myth_narrator.Manage_events(m_generated_history,
                                     m_ticks_completed);
 
       // Refresh the ID lists managed by the narrator

--- a/src/generators/narrators/end_times_era_narrator.cpp
+++ b/src/generators/narrators/end_times_era_narrator.cpp
@@ -26,9 +26,7 @@ void et_nar::Create_entities(his_gen::Entities& entities,
 
 ///////////////////////////////////////////////////////////////////////
 
-void et_nar::Manage_events(his_gen::Entities& entities,
-                           his_gen::Events& events,
-                           his_gen::Entity_relationships& entity_relationships,
+void et_nar::Manage_events(his_gen::Generated_history& history_of_the_world,
                            const uint64_t current_tick)
 {
   // NOOP

--- a/src/generators/narrators/end_times_era_narrator.h
+++ b/src/generators/narrators/end_times_era_narrator.h
@@ -44,14 +44,10 @@ public:
 
   /**
    * @brief Create new events and run scheduled events
-   * @param entities The vector of entity pointers to reference when creating events
-   * @param events The vector of events to populate
-   * @param entity_relationships The vector of entity relationships to populate
+   * @param history_of_the_world
    * @param current_tick The current generation tick
    */
-  void Manage_events(his_gen::Entities& entities,
-                     his_gen::Events& events,
-                     his_gen::Entity_relationships& entity_relationships,
+  void Manage_events(his_gen::Generated_history& history_of_the_world,
                      const uint64_t current_tick) override;
 
 protected:

--- a/src/generators/narrators/historical_era_narrator.cpp
+++ b/src/generators/narrators/historical_era_narrator.cpp
@@ -26,9 +26,7 @@ void hist_nar::Create_entities(his_gen::Entities& entities,
 
 ///////////////////////////////////////////////////////////////////////
 
-void hist_nar::Manage_events(his_gen::Entities& entities,
-                             his_gen::Events& events,
-                             his_gen::Entity_relationships& entity_relationships,
+void hist_nar::Manage_events(his_gen::Generated_history& history_of_the_world,
                              const uint64_t current_tick)
 {
   // NOOP

--- a/src/generators/narrators/historical_era_narrator.h
+++ b/src/generators/narrators/historical_era_narrator.h
@@ -44,14 +44,10 @@ public:
 
   /**
    * @brief Create new events and run scheduled events
-   * @param entities The vector of entity pointers to reference when creating events
-   * @param events The vector of events to populate
-   * @param entity_relationships The vector of entity relationships to populate
+   * @param history_of_the_world
    * @param current_tick The current generation tick
    */
-  void Manage_events(his_gen::Entities& entities,
-                     his_gen::Events& events,
-                     his_gen::Entity_relationships& entity_relationships,
+  void Manage_events(his_gen::Generated_history& history_of_the_world,
                      const uint64_t current_tick) override;
 
 protected:

--- a/src/generators/narrators/mythological_era_narrator.cpp
+++ b/src/generators/narrators/mythological_era_narrator.cpp
@@ -56,13 +56,17 @@ void myth_nar::Create_entities(his_gen::Entities& entities,
 
 ///////////////////////////////////////////////////////////////////////
 
-void myth_nar::Manage_events(his_gen::Entities& entities,
-                             his_gen::Events& events,
-                             his_gen::Entity_relationships& entity_relationships,
+void myth_nar::Manage_events(his_gen::Generated_history& history_of_the_world,
                              const uint64_t current_tick)
 {
   // Run events that were scheduled previously
-  run_scheduled_events(entities, entity_relationships, current_tick);
+  run_scheduled_events(history_of_the_world,
+                       current_tick);
+
+  // Refs to main history object, for convienence
+  Entities& entities = history_of_the_world.Get_entities();
+  Events& events = history_of_the_world.Get_events();
+  Entity_relationships& entity_relationships = history_of_the_world.Get_entity_relationships();
 
   // TODO Put this into another helper function or something?
   // Create new events and run them
@@ -86,7 +90,7 @@ void myth_nar::Manage_events(his_gen::Entities& entities,
     if(triggering_entity->Event_is_valid(new_event->Get_event_type(), current_tick))
     {
       // Run the event
-      new_event->Run(entities, entity_relationships, m_event_scheduler);
+      new_event->Run(history_of_the_world, m_event_scheduler);
     }
     else
     {

--- a/src/generators/narrators/mythological_era_narrator.h
+++ b/src/generators/narrators/mythological_era_narrator.h
@@ -53,9 +53,7 @@ public:
    * @param entity_relationships The vector of entity relationships to populate
    * @param current_tick The current generation tick
    */
-  void Manage_events(his_gen::Entities& entities,
-                     his_gen::Events& events,
-                     his_gen::Entity_relationships& entity_relationships,
+  void Manage_events(his_gen::Generated_history& history_of_the_world,
                      const uint64_t current_tick) override;
 
   /**

--- a/src/generators/narrators/narrator_base.h
+++ b/src/generators/narrators/narrator_base.h
@@ -59,14 +59,10 @@ public:
   /**
    * @brief Inheriting classes must implement this function to create new events
    * and manage scheduled events.
-   * @param entities The vector of entity pointers to reference when creating events
-   * @param events The vector of events to populate
-   * @param entity_relationships The vector of entity relationships to populate
+   * @param history_of_the_world
    * @current_tick The current generation tick
    */
-  virtual void Manage_events(his_gen::Entities& entities,
-                             his_gen::Events& events,
-                             his_gen::Entity_relationships& entity_relationships,
+  virtual void Manage_events(his_gen::Generated_history& history_of_the_world,
                              const uint64_t current_tick) =0;
 
   /**
@@ -131,12 +127,10 @@ protected:
   // Implementation
   /**
    * @brief Run events that have been scheduled by other events
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param current_tick
    */
-  void run_scheduled_events(his_gen::Entities& entities,
-                            his_gen::Entity_relationships entity_relationships,
+  void run_scheduled_events(his_gen::Generated_history& history_of_the_world,
                             const uint64_t current_tick)
   {
     // Temp instance of scheduler, so we can avoid an infinte loop if using the
@@ -149,12 +143,11 @@ protected:
       Scheduled_event sched = m_event_scheduler.Get_next_event(current_tick);
       // Make it
       std::shared_ptr<Event_base> scheduled = his_gen::Event_factory::Create_event(sched.Get_scheduled_event_type(),
-                                                                                   entities[sched.Get_triggering_entity()],
+                                                                                   history_of_the_world.Get_entities()[sched.Get_triggering_entity()],
                                                                                    current_tick,
                                                                                    sched.Get_triggering_event());
       // Run it
-      scheduled->Run(entities,
-                     entity_relationships,
+      scheduled->Run(history_of_the_world,
                      temp_scheduler);
     }
 

--- a/src/models/entities/entity_base.h
+++ b/src/models/entities/entity_base.h
@@ -311,7 +311,7 @@ inline void to_json(nlohmann::json& json, const his_gen::Entity_base& entity_bas
   {
     {"id", entity_base.Get_entity_id()},
     {"entity_type", his_gen::Enum_to_string(entity_base.Get_entity_type(),
-                                              entity_type_lookup)},
+                                            entity_type_lookup)},
     {"name", entity_base.Get_name()},
     {"title", entity_base.Get_title()},
     {"relationship_ids", entity_base.Get_relationship_ids()},

--- a/src/models/entities/entity_base.h
+++ b/src/models/entities/entity_base.h
@@ -16,6 +16,7 @@
 // Application files
 #include <utils/history_generator_utils.h>
 #include <models/data_definitions.h>
+#include <models/events/event_base.h>
 
 namespace his_gen
 {

--- a/src/models/entities/entity_sentient.cpp
+++ b/src/models/entities/entity_sentient.cpp
@@ -8,7 +8,6 @@
 // JSON
 
 // Application files
-#include <defs/json_helper_defs.h>
 #include <models/entities/entity_sentient.h>
 #include <models/data_definitions.h>
 #include <modules/names.h>

--- a/src/models/event_visitor.h
+++ b/src/models/event_visitor.h
@@ -11,7 +11,6 @@
 
 // Application files
 #include <utils/history_generator_utils.h>
-#include <models/entities/entity_base.h>
 
 namespace his_gen
 {

--- a/src/models/events/courtship_event.cpp
+++ b/src/models/events/courtship_event.cpp
@@ -114,12 +114,11 @@ his_gen::Courtship_event::Courtship_event(std::shared_ptr<Entity_base>& triggeri
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Courtship_event::Run(his_gen::Entities& entities,
-                                   his_gen::Entity_relationships& entity_relationships,
+void his_gen::Courtship_event::Run(his_gen::Generated_history& history_of_the_world,
                                    Event_scheduler& event_scheduler)
 {
   // Check in coming relationship for the triggering event
-
+  Get_triggering_event_id();
 
 //  // The entity that triggered the event
 //  std::shared_ptr<his_gen::Entity_base> triggering_entity = Get_triggering_entity();

--- a/src/models/events/courtship_event.h
+++ b/src/models/events/courtship_event.h
@@ -44,12 +44,10 @@ public:
 
   /**
    * @brief Run
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/events/elopement_event.cpp
+++ b/src/models/events/elopement_event.cpp
@@ -27,8 +27,7 @@ his_gen::Elopement_event::Elopement_event(std::shared_ptr<Entity_base>& triggeri
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Elopement_event::Run(his_gen::Entities& entities,
-                                   his_gen::Entity_relationships& entity_relationships,
+void his_gen::Elopement_event::Run(his_gen::Generated_history& history_of_the_world,
                                    Event_scheduler& event_scheduler)
 {
 

--- a/src/models/events/elopement_event.h
+++ b/src/models/events/elopement_event.h
@@ -37,12 +37,10 @@ public:
 
   /**
    * @brief Run
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/events/event_base.h
+++ b/src/models/events/event_base.h
@@ -10,17 +10,22 @@
 #include <memory>
 #include <string>
 #include <unordered_set>
-#include <boost/uuid/nil_generator.hpp>
 
-// JSON
+// 3rd party
+#include <boost/uuid/nil_generator.hpp>
+#include <boost/uuid/random_generator.hpp>
 #include <deps/json.hpp>
 
 // Application files
 #include <defs/history_generator_aliases.h>
-#include <utils/history_generator_utils.h>
 #include <defs/history_generator_defs.h>
+#include <defs/json_helper_defs.h>
+
+#include <models/data_definitions.h>
 #include <models/generated_history.h>
 #include <models/event_visitor.h>
+
+#include <utils/history_generator_utils.h>
 
 namespace his_gen
 {

--- a/src/models/events/event_base.h
+++ b/src/models/events/event_base.h
@@ -19,8 +19,7 @@
 #include <defs/history_generator_aliases.h>
 #include <utils/history_generator_utils.h>
 #include <defs/history_generator_defs.h>
-#include <models/entities/entity_base.h>
-#include <models/relations/entity_relationship.h>
+#include <models/generated_history.h>
 #include <models/event_visitor.h>
 
 namespace his_gen
@@ -77,12 +76,10 @@ public:
    * what 'Run' means.
    * @details By default, the value of `m_event_changes_state` will be used
    * to determine if this event has created meaningful change that should be saved
-   * @param entities The current set of entities, for resolving events
-   * @param entity_relationships Current set of relationships, if the event requires a new one be added
+   * @param history_of_the_world The current `Generated_history` object
    * @param event_scheduler Object to track upcoming events that result from this event
    */
-  virtual void Run(his_gen::Entities& entities,
-                   his_gen::Entity_relationships& entity_relationships,
+  virtual void Run(his_gen::Generated_history& history_of_the_world,
                    Event_scheduler& event_scheduler) = 0;
 
   /**

--- a/src/models/events/marriage_event.cpp
+++ b/src/models/events/marriage_event.cpp
@@ -27,8 +27,7 @@ his_gen::Marriage_event::Marriage_event(std::shared_ptr<Entity_base>& triggering
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Marriage_event::Run(his_gen::Entities& entities,
-                                  his_gen::Entity_relationships& entity_relationships,
+void his_gen::Marriage_event::Run(his_gen::Generated_history& history_of_the_world,
                                   Event_scheduler& event_scheduler)
 {
 

--- a/src/models/events/marriage_event.h
+++ b/src/models/events/marriage_event.h
@@ -37,12 +37,10 @@ public:
 
   /**
    * @brief Run
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/events/reproduce_event.cpp
+++ b/src/models/events/reproduce_event.cpp
@@ -27,8 +27,7 @@ his_gen::Reproduce_event::Reproduce_event(std::shared_ptr<Entity_base>& triggeri
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Reproduce_event::Run(his_gen::Entities& entities,
-                                   his_gen::Entity_relationships& entity_relationships,
+void his_gen::Reproduce_event::Run(his_gen::Generated_history& history_of_the_world,
                                    Event_scheduler& event_scheduler)
 {
 

--- a/src/models/events/reproduce_event.h
+++ b/src/models/events/reproduce_event.h
@@ -38,12 +38,10 @@ public:
 
   /**
    * @brief Run
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/events/secret_affair_event.cpp
+++ b/src/models/events/secret_affair_event.cpp
@@ -27,8 +27,7 @@ his_gen::Secret_affair_event::Secret_affair_event(std::shared_ptr<Entity_base>& 
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Secret_affair_event::Run(his_gen::Entities& entities,
-                                       his_gen::Entity_relationships& entity_relationships,
+void his_gen::Secret_affair_event::Run(his_gen::Generated_history& history_of_the_world,
                                        Event_scheduler& event_scheduler)
 {
 

--- a/src/models/events/secret_affair_event.h
+++ b/src/models/events/secret_affair_event.h
@@ -40,12 +40,10 @@ public:
 
   /**
    * @brief Run
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/events/seek_partner_event.cpp
+++ b/src/models/events/seek_partner_event.cpp
@@ -5,6 +5,7 @@
 // Standard
 #include <models/events/seek_partner_event.h>
 #include <models/entities/entity_base.h>
+#include <models/relations/entity_relationship.h>
 #include <utils/event_scheduler.h>
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/models/events/seek_partner_event.cpp
+++ b/src/models/events/seek_partner_event.cpp
@@ -33,14 +33,18 @@ his_gen::Seek_partner_event::Seek_partner_event(std::shared_ptr<Entity_base>& tr
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Seek_partner_event::Run(his_gen::Entities& entities,
-                                      his_gen::Entity_relationships& entity_relationships,
+void his_gen::Seek_partner_event::Run(his_gen::Generated_history& history_of_the_world,
                                       Event_scheduler& event_scheduler)
 {
-  // Check for entity attraction
+  // Pairs to hold attracted entities
   std::vector<std::pair<std::shared_ptr<his_gen::Entity_base>,
                         std::shared_ptr<his_gen::Entity_base>>> pairs;
 
+  // Generated history refs for convienence
+  Entities& entities = history_of_the_world.Get_entities();
+  Entity_relationships& entity_relationships = history_of_the_world.Get_entity_relationships();
+
+  // Get the entity we'll be working wtih
   std::shared_ptr<his_gen::Entity_base> triggering_entity = entities[Get_triggering_entity_id()];
 
   // Loop through all entities

--- a/src/models/events/seek_partner_event.h
+++ b/src/models/events/seek_partner_event.h
@@ -40,11 +40,11 @@ public:
   ~Seek_partner_event(){}
 
   /**
-   * @brief Run the event
-   * @param entities The current set of entities, for check attraction
+   * @brief Run
+   * @param history_of_the_world
+   * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/events/social_scandal_event.cpp
+++ b/src/models/events/social_scandal_event.cpp
@@ -27,8 +27,7 @@ his_gen::Social_scandal_event::Social_scandal_event(std::shared_ptr<Entity_base>
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Social_scandal_event::Run(his_gen::Entities& entities,
-                                        his_gen::Entity_relationships& entity_relationships,
+void his_gen::Social_scandal_event::Run(his_gen::Generated_history& history_of_the_world,
                                         Event_scheduler& event_scheduler)
 {
 

--- a/src/models/events/social_scandal_event.h
+++ b/src/models/events/social_scandal_event.h
@@ -40,12 +40,10 @@ public:
 
   /**
    * @brief Run
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/events/toxic_relationship_event.cpp
+++ b/src/models/events/toxic_relationship_event.cpp
@@ -27,8 +27,7 @@ his_gen::Toxic_relationship_event::Toxic_relationship_event(std::shared_ptr<Enti
 
 //////////////////////////////////////////////////////////////////////
 
-void his_gen::Toxic_relationship_event::Run(his_gen::Entities& entities,
-                                            his_gen::Entity_relationships& entity_relationships,
+void his_gen::Toxic_relationship_event::Run(his_gen::Generated_history& history_of_the_world,
                                             Event_scheduler& event_scheduler)
 {
 

--- a/src/models/events/toxic_relationship_event.h
+++ b/src/models/events/toxic_relationship_event.h
@@ -40,12 +40,10 @@ public:
 
   /**
    * @brief Run
-   * @param entities
-   * @param entity_relationships
+   * @param history_of_the_world
    * @param event_scheduler
    */
-  void Run(his_gen::Entities& entities,
-           his_gen::Entity_relationships& entity_relationships,
+  void Run(his_gen::Generated_history& history_of_the_world,
            Event_scheduler& event_scheduler) override;
 
   /**

--- a/src/models/generated_history.cpp
+++ b/src/models/generated_history.cpp
@@ -21,7 +21,7 @@ void his_gen::to_json(nlohmann::json& json,
 {
   json = nlohmann::json
   {
-    //{"entities", generated_history.Get_entities()},
+    {"entities", generated_history.Get_entities()},
     {"events", generated_history.Get_events()},
     {"entity_relationships", generated_history.Get_entity_relationships()}
   };

--- a/src/models/generated_history.cpp
+++ b/src/models/generated_history.cpp
@@ -2,8 +2,17 @@
  * Copyright (C) 2024 Nate Anderson - All Rights Reserved
  */
 
-// Standard
+// Standard libs
+
+// JSON
+
+// Application files
 #include <models/generated_history.h>
+
+// Models
+#include <models/entities/entity_base.h>
+#include <models/events/event_base.h>
+#include <models/relations/entity_relationship.h>
 
 ///////////////////////////////////////////////////////////////////////
 

--- a/src/models/generated_history.cpp
+++ b/src/models/generated_history.cpp
@@ -21,7 +21,7 @@ void his_gen::to_json(nlohmann::json& json,
 {
   json = nlohmann::json
   {
-    {"entities", generated_history.Get_entities()},
+    //{"entities", generated_history.Get_entities()},
     {"events", generated_history.Get_events()},
     {"entity_relationships", generated_history.Get_entity_relationships()}
   };

--- a/src/models/generated_history.h
+++ b/src/models/generated_history.h
@@ -12,16 +12,16 @@
 
 // Application files
 #include <utils/history_generator_utils.h>
+#include <defs/history_generator_aliases.h>
 
 // Models
-#include <models/entities/entity_type.h>
-#include <models/events/event_base.h>
-#include <models/relations/entity_relationship.h>
-#include <models/relations/entity_type_relationship_type.h>
 #include <models/relationships/relationship_type.h>
 
 namespace his_gen
 {
+
+class Entity_type_relationship_type;
+
 /**
  * @brief The 'master' data type to contain vectors of all generated history
  */


### PR DESCRIPTION
use the generated history object as a param all over the place, rather that pulling specific things off it